### PR TITLE
Remove Flow checks from number.js.flow, models/index.js.flow

### DIFF
--- a/src/components/number.js.flow
+++ b/src/components/number.js.flow
@@ -7,17 +7,3 @@ export type IEOLocaleNumberProps = Intl$NumberFormatOptions & {
 }
 
 declare export var EOLocaleNumber: React$StatelessFunctionalComponent<IEOLocaleNumberProps>;
-
-
-
-({style: 'decimal', value: 1}: IEOLocaleNumberProps);
-
-/**
- * $ExpectError
- */
-({style: 'decimal'}: IEOLocaleNumberProps);
-
-/**
- * $ExpectError
- */
-({style: 'decimal', value: "xxx"}: IEOLocaleNumberProps);

--- a/src/models/index.js.flow
+++ b/src/models/index.js.flow
@@ -13,13 +13,3 @@ export type IFormatMessageOptions = TFormatMessageOptions & {
 	defaultMessage?: string
 }
 
-({ a: '0' }: IFormatMessageOptions);
-
-({ a: 1 }: IFormatMessageOptions);
-
-({ a: '0', defaultMessage: '' }: IFormatMessageOptions);
-
-/**
- * $ExpectError
- */
-({ a: '0', defaultMessage: 1 }: IFormatMessageOptions);


### PR DESCRIPTION
Some fix needed after the test on a real project. Suppress comments (`$ExpectError`) may be disabled, in this case Flow throws error.