### PR TITLE
fix case with id using dot

### DIFF
--- a/packages/core/src/__tests__/nested_json.test.ts
+++ b/packages/core/src/__tests__/nested_json.test.ts
@@ -11,14 +11,19 @@ const locales: Locale[] = [
       page2: {
         hello: 'Hello react-intl-universal!',
       },
+      'page.3': 'Hello value with dotted key!'
     },
   },
 ];
 
 describe('Nested json', () => {
-  test('Should translate', () => {
-    const translator = new Translator('en', locales);
+  const translator = new Translator('en', locales);
 
+  test('Should translate', () => {
     expect(translator.translate('page1.hello')).toBe('Hello world');
+  });
+
+  test('Should translate with dotted key', () => {    
+    expect(translator.translate('page.3')).toBe('Hello value with dotted key!');
   });
 });

--- a/packages/core/src/translator.ts
+++ b/packages/core/src/translator.ts
@@ -51,12 +51,14 @@ export class Translator {
     defaultMessage?: string,
   ): Message | object | null => {
     if (!this.memo[id]) {
-      let message: object | string | undefined = id
-        .split('.')
-        .reduce(
-          (acc, current) => (acc ? (acc as any)[current] : undefined),
-          this.messages,
-        );
+      let message: object | string | undefined =
+        (this.messages as any)[id] ||
+        id
+          .split('.')
+          .reduce(
+            (acc, current) => (acc ? (acc as any)[current] : undefined),
+            this.messages,
+          );
 
       if (typeof message !== 'string') {
         this.onError(new Error(`[eo-locale] id missing "${id}"`));


### PR DESCRIPTION
Hi! Our project uses IDs in a format like this
`"AUTH.LOGIN": "Login",
  "AUTH.NAME": "Name",`
So when using the last version of the library, the IDs with dots are being ignored. I added checking for that case
